### PR TITLE
feat: bundle kemulator nnmod v2.20 to macos `.app`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build macOS DMG
+name: Build macOS App
 
 on:
   push:
@@ -45,11 +45,11 @@ jobs:
             --exclude='*.so' \
             "$GITHUB_WORKSPACE/kemnnx64/" "$GITHUB_WORKSPACE/build-mac/"
 
-      - name: Build DMG with jpackage
+      - name: Build .app with jpackage
         env:
           APP_NAME: KEmulator
         run: |
-          jpackage --type dmg \
+          jpackage --type app-image \
             --name "$APP_NAME" \
             --app-version "${KEMULATOR_VERSION}" \
             --dest "$GITHUB_WORKSPACE/dist" \
@@ -61,13 +61,18 @@ jobs:
             --java-options '--enable-native-access=ALL-UNNAMED' \
             --vendor 'KEmulator nnmod' \
             --runtime-image "$JAVA_HOME"
-          echo "Built: dist/${APP_NAME}-${KEMULATOR_VERSION}.dmg"
+          echo "Built: dist/${APP_NAME}.app"
 
-      - name: Upload DMG artifact
+      - name: Create app bundle zip
+        run: |
+          cd "$GITHUB_WORKSPACE/dist"
+          zip -r "KEmulator-${{ env.KEMULATOR_VERSION }}-macos.app.zip" KEmulator.app/
+
+      - name: Upload app bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: KEmulator-${KEMULATOR_VERSION}-dmg
-          path: dist/*.dmg
+          name: KEmulator-v${{ env.KEMULATOR_VERSION }}-macos.app.zip
+          path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos.app.zip
           if-no-files-found: error
 
     #   - name: Upload release asset (on tag)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,9 @@ env:
 jobs:
   pack-macos:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        arch: [x64, aarch64]
     defaults:
       run:
         shell: bash
@@ -26,8 +29,9 @@ jobs:
       - name: Set up Temurin JDK (with jpackage)
         uses: actions/setup-java@v4
         with:
-          distribution: temurin
+          distribution: 'temurin'
           java-version: '24'
+          architecture: ${{ matrix.arch }}
 
       - name: Download Kemulator Release
         run: |
@@ -66,13 +70,13 @@ jobs:
       - name: Create app bundle zip
         run: |
           cd "$GITHUB_WORKSPACE/dist"
-          zip -r "KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip" KEmulator.app/
+          zip -r "KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip" KEmulator.app/
 
       - name: Upload app bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip
-          path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip
+          name: KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip
+          path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip
           if-no-files-found: error
 
     #   - name: Upload release asset (on tag)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: Build macOS DMG
+
+on:
+  push:
+    branches: [ "**" ]
+    tags: [ "v*" ]
+  pull_request:
+    branches: [ "**" ]
+
+permissions:
+  contents: write
+
+env:
+    KEMULATOR_VERSION: "2.20"
+
+jobs:
+  pack-macos:
+    runs-on: macos-latest
+    defaults:
+      run:
+        shell: bash
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Temurin JDK (with jpackage)
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '24'
+
+      - name: Download Kemulator Release
+        run: |
+          curl -L -o kemnnx64.zip "https://github.com/shinovon/KEmulator/releases/download/v${{ env.KEMULATOR_VERSION }}/kemnnx64.v${{ env.KEMULATOR_VERSION }}.zip"
+          unzip kemnnx64.zip
+          ls -la kemnnx64/
+
+      - name: Stage macOS files (exclude Windows/Linux natives and .package)
+        run: |
+          rm -rf "build-mac" "dist"
+          mkdir -p "build-mac" "dist"
+          rsync -a --delete \
+            --exclude='.package' \
+            --exclude='*.dll' \
+            --exclude='*.so' \
+            "$GITHUB_WORKSPACE/kemnnx64/" "$GITHUB_WORKSPACE/build-mac/"
+
+      - name: Build DMG with jpackage
+        env:
+          APP_NAME: KEmulator
+        run: |
+          jpackage --type dmg \
+            --name "$APP_NAME" \
+            --app-version "${KEMULATOR_VERSION}" \
+            --dest "$GITHUB_WORKSPACE/dist" \
+            --input "$GITHUB_WORKSPACE/build-mac" \
+            --main-jar KEmulator.jar \
+            --java-options '-Xmx512M' \
+            --java-options '-Dfile.encoding=UTF-8' \
+            --java-options '-Djava.library.path=$APPDIR/app' \
+            --java-options '--enable-native-access=ALL-UNNAMED' \
+            --vendor 'KEmulator nnmod' \
+            --runtime-image "$JAVA_HOME"
+          echo "Built: dist/${APP_NAME}-${KEMULATOR_VERSION}.dmg"
+
+      - name: Upload DMG artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: KEmulator-${KEMULATOR_VERSION}-dmg
+          path: dist/*.dmg
+          if-no-files-found: error
+
+    #   - name: Upload release asset (on tag)
+    #     if: startsWith(github.ref, 'refs/tags/')
+    #     uses: softprops/action-gh-release@v2
+    #     with:
+    #       files: dist/*.dmg
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,16 @@ name: Build macOS App
 
 on:
   push:
-    branches: [ "**" ]
-    tags: [ "v*" ]
+    branches: ["**"]
+    tags: ["v*"]
   pull_request:
-    branches: [ "**" ]
+    branches: ["**"]
 
 permissions:
   contents: write
 
 env:
-    KEMULATOR_VERSION: "2.20"
+  KEMULATOR_VERSION: "2.20"
 
 jobs:
   pack-macos:
@@ -29,8 +29,8 @@ jobs:
       - name: Set up Temurin JDK (with jpackage)
         uses: actions/setup-java@v4
         with:
-          distribution: 'temurin'
-          java-version: '24'
+          distribution: "temurin"
+          java-version: "24"
           architecture: ${{ matrix.arch }}
 
       - name: Download Kemulator Release
@@ -39,7 +39,8 @@ jobs:
           unzip kemnnx64.zip
           ls -la kemnnx64/
 
-      - name: Stage macOS files (exclude Windows/Linux natives and .package)
+      - name: Stage macOS files for macos aarch64
+        if: matrix.arch == 'aarch64'
         run: |
           rm -rf "./build-mac/"
           rsync -a --delete \
@@ -52,7 +53,37 @@ jobs:
             --exclude='*win32*' \
             --exclude='*.sh' \
             --exclude='*.bat' \
+            --exclude='*x86*' \
+            --exclude='lwjgl-glfw-natives-macos.jar' \
+            --exclude='lwjgl-natives-macos.jar' \
+            --exclude='lwjgl-opengl-natives-macos.jar' \
+            --exclude='lwjgl3-swt-macos.jar' \
+            --exclude='libamrdecoder.dylib' \
             "./kemnnx64/" "./build-mac/"
+
+      - name: Stage macOS files for macos x64
+        if: matrix.arch == 'x64'
+        run: |
+          rm -rf "./build-mac/"
+          rsync -a --delete \
+            --exclude='.package' \
+            --exclude='*.dll' \
+            --exclude='*.so' \
+            --exclude='*linux*' \
+            --exclude='*windows*' \
+            --exclude='*android*' \
+            --exclude='*win32*' \
+            --exclude='*.sh' \
+            --exclude='*.bat' \
+            --exclude='*aarch64*' \
+            --exclude='*arm64*' \
+            "./kemnnx64/" "./build-mac/"
+
+      - name: Use the latest libjinput-osx native library to support macos aarch64
+        run: |
+          rm ./build-mac/libjinput-osx.dylib ./build-mac/libjinput-osx.jnilib
+          curl -L -o osx-plugin-2.0.10-natives-osx.jar "https://repo1.maven.org/maven2/net/java/jinput/osx-plugin/2.0.10/osx-plugin-2.0.10-natives-osx.jar"
+          unzip -j osx-plugin-2.0.10-natives-osx.jar "libjinput-osx.jnilib" -d "./build-mac/"
 
       - name: Build .app with jpackage
         run: |
@@ -82,9 +113,8 @@ jobs:
           path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip
           if-no-files-found: error
 
-    #   - name: Upload release asset (on tag)
-    #     if: startsWith(github.ref, 'refs/tags/')
-    #     uses: softprops/action-gh-release@v2
-    #     with:
-    #       files: dist/*.dmg
-
+      - name: Upload release asset (on tag)
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,8 @@ jobs:
 
       - name: Stage macOS files (exclude Windows/Linux natives and .package)
         run: |
-          rm -rf "build-mac" "dist"
-          mkdir -p "build-mac" "dist"
+          rm -rf "$GITHUB_WORKSPACE/build-mac" "$GITHUB_WORKSPACE/dist"
+          mkdir -p "$GITHUB_WORKSPACE/build-mac" "$GITHUB_WORKSPACE/dist"
           rsync -a --delete \
             --exclude='.package' \
             --exclude='*.dll' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,23 +41,27 @@ jobs:
 
       - name: Stage macOS files (exclude Windows/Linux natives and .package)
         run: |
-          rm -rf "$GITHUB_WORKSPACE/build-mac" "$GITHUB_WORKSPACE/dist"
-          mkdir -p "$GITHUB_WORKSPACE/build-mac" "$GITHUB_WORKSPACE/dist"
+          rm -rf "./build-mac/"
           rsync -a --delete \
             --exclude='.package' \
             --exclude='*.dll' \
             --exclude='*.so' \
-            "$GITHUB_WORKSPACE/kemnnx64/" "$GITHUB_WORKSPACE/build-mac/"
+            --exclude='*linux*' \
+            --exclude='*windows*' \
+            --exclude='*android*' \
+            --exclude='*win32*' \
+            --exclude='*.sh' \
+            --exclude='*.bat' \
+            "./kemnnx64/" "./build-mac/"
 
       - name: Build .app with jpackage
-        env:
-          APP_NAME: KEmulator
         run: |
+          rm -rf dist
           jpackage --type app-image \
-            --name "$APP_NAME" \
+            --name "KEmulator" \
             --app-version "${KEMULATOR_VERSION}" \
-            --dest "$GITHUB_WORKSPACE/dist" \
-            --input "$GITHUB_WORKSPACE/build-mac" \
+            --dest "dist" \
+            --input "./build-mac" \
             --main-jar KEmulator.jar \
             --java-options '-Xmx512M' \
             --java-options '-Dfile.encoding=UTF-8' \
@@ -65,11 +69,10 @@ jobs:
             --java-options '--enable-native-access=ALL-UNNAMED' \
             --vendor 'KEmulator nnmod' \
             --runtime-image "$JAVA_HOME"
-          echo "Built: dist/${APP_NAME}.app"
 
       - name: Create app bundle zip
         run: |
-          cd "$GITHUB_WORKSPACE/dist"
+          cd dist
           zip -r "KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-${{ matrix.arch }}.app.zip" KEmulator.app/
 
       - name: Upload app bundle artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,6 +79,14 @@ jobs:
             --exclude='*arm64*' \
             "./kemnnx64/" "./build-mac/"
 
+      - name: Fix lwjgl natives for macos x64
+        if: matrix.arch == 'x64'
+        run: |
+          cp ./build-mac/lwjgl-glfw-natives-macos.jar ./build-mac/lwjgl-glfw-natives-macos-x86.jar
+          cp ./build-mac/lwjgl-natives-macos.jar ./build-mac/lwjgl-natives-macos-x86.jar
+          cp ./build-mac/lwjgl-opengl-natives-macos.jar ./build-mac/lwjgl-opengl-natives-macos-x86.jar
+          cp ./build-mac/lwjgl3-swt-macos.jar ./build-mac/lwjgl3-swt-macos-x86.jar
+
       - name: Use the latest libjinput-osx native library to support macos aarch64
         run: |
           rm ./build-mac/libjinput-osx.dylib ./build-mac/libjinput-osx.jnilib

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,13 +66,13 @@ jobs:
       - name: Create app bundle zip
         run: |
           cd "$GITHUB_WORKSPACE/dist"
-          zip -r "KEmulator-${{ env.KEMULATOR_VERSION }}-macos.app.zip" KEmulator.app/
+          zip -r "KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip" KEmulator.app/
 
       - name: Upload app bundle artifact
         uses: actions/upload-artifact@v4
         with:
-          name: KEmulator-v${{ env.KEMULATOR_VERSION }}-macos.app.zip
-          path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos.app.zip
+          name: KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip
+          path: dist/KEmulator-v${{ env.KEMULATOR_VERSION }}-macos-arm64.app.zip
           if-no-files-found: error
 
     #   - name: Upload release asset (on tag)

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+.DS_Store
+.vscode
+
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+replay_pid*
+
+build-mac/
+dist/
+kemnnx64/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
-# KEmulator-nnmod-macos-pack
+# KEmulator nnmod macOS App Bundles
+
+This repository packages [KEmulator nnmod](https://github.com/shinovon/KEmulator) into macOS `.app` bundles for easy installation and use on macOS systems.
+
+## About KEmulator
+
+KEmulator is a Java ME (J2ME) emulator that allows you to run mobile Java applications and games on your computer. The nnmod version includes various enhancements and improvements over the original emulator.
+
+## Downloads
+
+Pre-built macOS app bundles are available in the [Releases](https://github.com/rwv/KEmulator-nnmod-macos/releases) section.
+
+### Supported Architectures
+
+- **Intel (x64)**: For Intel-based Macs
+- **Apple Silicon (aarch64)**: For M1/M2/M3 Macs
+
+## Installation
+
+1. Download the appropriate `.app.zip` file for your Mac architecture from the [releases page](https://github.com/rwv/KEmulator-nnmod-macos/releases)
+2. Extract the zip file
+3. Move `KEmulator.app` to your Applications folder
+4. Launch KEmulator from your Applications folder or Launchpad
+
+## License
+
+This packaging repository follows the same license as the original KEmulator project. Please refer to the [original repository](https://github.com/shinovon/KEmulator) for license details.


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automate building and packaging KEmulator nnmod as native macOS `.app` bundles for both Intel (x64) and Apple Silicon (aarch64) architectures. It also updates the `README.md` to provide clear documentation on the project, its purpose, supported architectures, installation instructions, and licensing information.

**CI/CD Automation:**

* Added a comprehensive workflow in `.github/workflows/ci.yml` to build, package, and release macOS `.app` bundles for both x64 and aarch64 architectures, including steps for downloading dependencies, staging files, handling native libraries, and uploading artifacts/releases.

**Documentation Improvements:**

* Updated `README.md` to describe the repository's purpose, provide download and installation instructions, clarify supported architectures, and specify licensing details.